### PR TITLE
Removing `sanitizeHtml` function (unused)

### DIFF
--- a/src/privileged/vpnRecommender/content/doorhanger/doorhanger.js
+++ b/src/privileged/vpnRecommender/content/doorhanger/doorhanger.js
@@ -30,8 +30,6 @@ const self = {
   },
 };
 
-const sanitizeHtml = (m) => { return m; }; // disabling the sanitization. not needed. only text from the code is sent.
-
 self.port.on("VpnRecommender::load", (data) => {
   content.addEventListener("load", () => load());
 });


### PR DESCRIPTION
This removes a function called `sanitizeHtml` that just returns its first parameter without doing anything.
The function here is not only unused but also insecure. The code looks sketchy, so I recommend removing the function altogether.